### PR TITLE
Add initial Oracle Linux support

### DIFF
--- a/distro/adaptation/oracle
+++ b/distro/adaptation/oracle
@@ -1,0 +1,138 @@
+apache2: httpd
+apt-file:
+autotools-dev: autoconf
+binutils-dev: binutils-devel
+btrfs-tools: btrfs-progs
+build-essential: make automake gcc gcc-c++ kernel-uek-devel rpm-build
+cgroup-bin: libcgroup
+dbench=4.0-2: dbench
+dpkg-dev: dpkg-devel
+f2fs-tools:
+freeglut3: freeglut
+fsmark: fs_mark
+gcc-4.9: gcc
+gcc-5: gcc
+gcc-6: gcc
+gfortran: gcc-c++
+hpcc:
+initramfs-tools: dracut
+iozone3: gnuplot*
+iproute2: iproute
+klibc-utils:
+libacl1-dev: libacl-devel
+libaio1: libaio libaio-devel
+libaio-dev: libaio-devel
+libarchive-dev: libarchive-devel
+libattr1-dev: libattr-devel
+libaudit-dev: audit-libs-devel
+libblas3: liblas-libs
+libblkid-dev: libblkid-devel
+libc6-dev: glibc-devel glibc-static
+libc6-dev:i386: glibc-devel.i686 glibc-static.i686
+libcairo2-dev: cairo-devel
+libcap2: libcap
+libcap-dev: libcap-devel
+libcap-ng-dev: libcap-ng-devel
+libdbd-mysql-perl: perl-DBD-MySQL
+libdbi-perl: perl-DBI
+libdbus-1-dev: dbus-devel
+libdrm-dev: libdrm-devel
+libdw-dev: libdwarf-devel
+libegl1-mesa-dev: mesa-libEGL-devel
+libelf-dev: elfutils-libelf-devel
+libfabric-dev: libfabric-devel
+libfdt-dev:
+libfuse-dev: fuse-devel
+libgbm-dev: mesa-libgbm-devel
+libgl1-mesa-dev: mesa-libglapi
+libgles2-mesa: mesa-libGLES
+libglib2.0-0: glib
+libglib2.0-dev: glib2-devel
+libglu-dev: mesa-libGLU-devel
+libgomp1: libgomp
+libhwloc-dev: hwloc-devel
+libiberty-dev:
+libibverbs-dev: libibverbs-devel
+libjson-c-dev: json-c-devel
+libklibc-dev:
+libkmod2: kmod-libs
+libkmod-dev: kmod-devel
+liblz-dev:
+liblzma-dev: xz-devel
+libmount-dev: libmount-devel
+libncurses5-dev: ncurses-devel
+libnl-3-200: libnl3
+libnl-3-dev: libnl3-devel
+libnl-genl-3-200: libnl3
+libnl-genl-3-dev: libnl3-devel
+libnl-route-3-dev: libnl3-devel
+libnuma1: numactl
+libnuma-dev: numactl-devel
+liboop-dev:
+liboop-dev: liboop
+libpcap0.8-dev: libpcap-devel
+libpcap0.8: libpcap
+libpcap-dev: libpcap-devel
+libpciaccess-dev: libpciaccess-devel
+libperl5.20: perl-libs
+libperl5.22: perl-libs
+libpixman-1-dev: pixman-devel
+libpng12-dev: libpng12-devel
+libpopt0: popt
+libpopt-dev: popt-devel
+librdmacm-dev: librdmacm-devel
+libreadline5: readline
+libsctp-dev: lksctp-tools-devel
+libselinux1:
+libsqlite3-dev: sqlite-devel
+libssl1.0.0: openssl-devel
+libssl1.1: openssl-devel
+libssl-dev: openssl-devel
+libtool-bin: libtool
+libudev1: systemd-libs
+libudev-dev: systemd-devel
+libunwind-dev: libunwind-devel
+libuuid1: libuuid
+libuv1-dev: libuv-devel
+libx11-xcb-dev: libX11-devel
+linux-libc-dev:
+linux-libc-dev:i386:
+linux-perf: perf
+linux-tools: perf
+mysql-server: mariadb
+ncurses-bin: ncurses
+netpipe-lam:
+netpipe-mpich2:
+netpipe-openmpi:
+netpipe-pvm:
+netpipe-tcp:
+nfs-common: nfs-utils
+nfs-kernel-server: nfs-utils
+perl-base:
+perl-modules-5.22: perl-CPAN
+perl-modules: perl-CPAN
+pixz: pxz
+pkg-config: pkgconfig
+plzip:
+postmark:
+python3-mako: python-pyramid-mako
+python3-markupsafe: python34-markupsafe
+python3-numpy: python34-numpy
+python3-six: python34-six
+python-minimal: python2
+python-numpy: numpy
+rt-tests: numactl-devel
+ruby-dev: ruby-devel
+ruby-git:
+ruby-gnuplot:
+sg3-utils: sg3_utils
+stress-ng:
+trinity:
+tshark: wireshark
+uuid-dev: libuuid-devel
+xfslibs-dev: xfsprogs-devel
+xinit: xorg-x11-xinit
+xorg:
+xutils-dev: imake
+xz-utils: xz
+zlib1g-dev: zlib-devel

--- a/distro/installer/oracle
+++ b/distro/installer/oracle
@@ -1,0 +1,6 @@
+if ! rpm -q epel-release >/dev/null; then
+	yum install -y epel-release
+	yum makecache fast
+fi
+
+yum install -y $*

--- a/lib/detect-system.sh
+++ b/lib/detect-system.sh
@@ -167,7 +167,7 @@ detect_system()
 		_system_name="Fedora"
 		_system_version="$(GREP_OPTIONS="" \command \grep -Eo '[0-9]+' ${rootfs}/etc/fedora-release | head -n 1)"
 	elif
-		[ -f ${rootfs}/etc/redhat-release ]
+		[ -f ${rootfs}/etc/redhat-release ] && [ ! -f ${rootfs}/etc/oracle-release ]
 	then
 		_system_name="$(
 		GREP_OPTIONS="" \command \grep -Eo 'CentOS|ClearOS|Mageia|PCLinuxOS|Scientific|ROSA Desktop|OpenMandriva' ${rootfs}/etc/redhat-release 2>/dev/null | \command \head -n 1 | \command \sed "s/ //"
@@ -179,6 +179,11 @@ detect_system()
 	then
 		_system_name="CentOS"
 		_system_version="$(GREP_OPTIONS="" \command \grep -Eo '[0-9\.]+' ${rootfs}/etc/centos-release  | \command \awk -F. '{print $1}' | head -n 1)"
+	elif
+		[ -f ${rootfs}/etc/oracle-release ]
+	then
+		_system_name="Oracle"
+		_system_version="$(GREP_OPTIONS="" \command \grep -Eo '[0-9\.]+' ${rootfs}/etc/oracle-release  | \command \awk -F. '{print $1}' | head -n 1)"
 	elif
 		[ -f ${rootfs}/etc/os-release ] &&
 			GREP_OPTIONS="" \command \grep "ID=\"eywa\"" ${rootfs}/etc/os-release >/dev/null

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -19,6 +19,7 @@ sync_distro_sources()
 	archlinux) yaourt -Sy ;;
 	opensuse)
 		zypper update ;;
+	oracle) yum update ;;
 	*) echo "Not support $distro to do update" ;;
 	esac
 }


### PR DESCRIPTION
These modifications add initial Oracle Linux support.

Verified with a few tests (hackbench, unixbench) on Oracle Linux 6.9.
make install, lkp install, lkp split-job, lkp run, lkp result work fine.

